### PR TITLE
🔮 using adjusted semantic-release-gitmoji

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - add-release
+      - add-release-experiment
 
 permissions:
   contents: read # for checkout

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "dependencies": {
         "@qiwi/multi-semantic-release": "^7.0.0",
         "semantic-release": "^21.1.1",
-        "semantic-release-gitmoji": "^1.6.4"
+        "semantic-release-gitmoji": "github:scottnath/semantic-release-gitmoji#release-notes-class"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -5711,8 +5711,8 @@
     },
     "node_modules/semantic-release-gitmoji": {
       "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/semantic-release-gitmoji/-/semantic-release-gitmoji-1.6.4.tgz",
-      "integrity": "sha512-mPkeKGKXlqKhWrlzi3mgRogTKnzOJAakrCdfBrgpG7z7WiP8sZ6pZP5Su+IJbj1RWbNBier/isVzvwE5RhozbQ==",
+      "resolved": "git+ssh://git@github.com/scottnath/semantic-release-gitmoji.git#e23a233442ccfc57610f4dc203fadfe68bb5fe06",
+      "license": "MIT",
       "dependencies": {
         "dateformat": "^3.0.3",
         "debug": "^4.3.2",
@@ -6397,6 +6397,8 @@
         "scottnath-experiments-a": "*"
       }
     },
-    "workspaces/meow": {}
+    "workspaces/meow": {
+      "name": "scottnath-experiments-meow"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
   "dependencies": {
     "@qiwi/multi-semantic-release": "^7.0.0",
     "semantic-release": "^21.1.1",
-    "semantic-release-gitmoji": "^1.6.4"
+    "semantic-release-gitmoji": "github:scottnath/semantic-release-gitmoji#release-notes-class"
   }
 }

--- a/workspaces/a/random.txt
+++ b/workspaces/a/random.txt
@@ -1,3 +1,3 @@
 vcbf
-fffff
+ffffff
 aaaaaaaa

--- a/workspaces/b/random.txt
+++ b/workspaces/b/random.txt
@@ -1,1 +1,1 @@
-fddf
+fddff

--- a/workspaces/meow/.releaserc.cjs
+++ b/workspaces/meow/.releaserc.cjs
@@ -19,6 +19,7 @@ module.exports = {
   branches: [
     { name: 'main', channel: 'latest', prerelease: false },
     { name: 'add-release', channel: 'ar', prerelease: true },
+    { name: 'add-release-experiment', channel: 'are', prerelease: true}
   ],
   debug: true,
   plugins: [


### PR DESCRIPTION

This pull request is against the [add-release branch](https://github.com/scottnath/experiments/tree/add-release) to show the minor differences between the two branches